### PR TITLE
feat: add support for query and mutation variables

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,7 @@ export function handleGraphQLRequest(
     const result = await graphql({
       schema,
       source: body.query,
+      variableValues: body.variables,
       contextValue,
     })
 


### PR DESCRIPTION
### Description

The current implementation is not sending the `variables` to the queries or the mutations, this PR adds the ability to use them

Error: 

<img width="591" alt="image" src="https://user-images.githubusercontent.com/801245/226800032-50fe1aef-969e-4460-82a0-6dd23f40bf46.png">

